### PR TITLE
composer: allow PHP 8, so Rector can use it fully

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "nikic/php-parser": "^4.10"
     },
     "require-dev": {


### PR DESCRIPTION
Hi, 
I'm trying to composer install Rector book, but fail with PHP 8 here.